### PR TITLE
support simulations with vhdl 08

### DIFF
--- a/hdl_runner/runner.py
+++ b/hdl_runner/runner.py
@@ -291,6 +291,7 @@ class Ghdl(Simulator):
         """
         Prepare GHDL-specific test arguments
         """
+        super()._pre_run()
         self.test_args.append('--std=08')
 
 def run(


### PR DESCRIPTION
**Issue:** GHDL simulation command fails to find the specified entity:

```
INFO: Running command ghdl -i --work=top --std=08 /hdl/some_core.vhd in directory /tmp/tmpzdqbnon8
INFO: Running command ghdl -m --work=top --std=08 some_entity in directory /tmp/tmpzdqbnon8
INFO: Running command ghdl -r --work=top --time-resolution=ps some_entity --vpi=/hdl/.venv/lib/python3.13/site-packages/cocotb/libs/libcocotbvpi_ghdl.so --vcd=tb_some_entity.vcd in directory /tmp/tmpzdqbnon8
/usr/bin/ghdl-mcode:error: cannot find entity or configuration some_entity
```

**Reason:** For GHDL, `--std=08` is included in build args but not in test args (Extracted from https://github.com/ghdl/ghdl/issues/2752)

**Fix:** Add `--std=08` to test args